### PR TITLE
Replaced http://ex with https://ex

### DIFF
--- a/chrome/lib/background.js
+++ b/chrome/lib/background.js
@@ -3,7 +3,7 @@ function setHentaiCookies() {
 		chrome.cookies.getAll({domain:'.e-hentai.org'}, function(got) {
 			for(var i = 0; i < got.length; i++) {
 				if(got[i].name.indexOf('ipb_') != -1 || got[i].name.indexOf('uconfig') != -1) {
-					chrome.cookies.set({url:'http://exhentai.org/', domain:'.exhentai.org', name:got[i].name, path:'/', value:got[i].value});
+					chrome.cookies.set({url:'https://exhentai.org/', domain:'.exhentai.org', name:got[i].name, path:'/', value:got[i].value});
 				}
 			}
 		});
@@ -18,11 +18,11 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 	if(request == 'cookieDataSet') {
 		sendResponse((setHentaiCookies() ? 'ok' : 'Unable to set cookies'));
 	} else if(request == 'deleteAllCookies') {
-		chrome.cookies.remove({name:"yay", url:"http://exhentai.org/"}, function(){});
-		chrome.cookies.remove({name:"ipb_anonlogin", url:"http://exhentai.org/"}, function(){});
-		chrome.cookies.remove({name:"ipb_member_id", url:"http://exhentai.org/"}, function(){});
-		chrome.cookies.remove({name:"ipb_pass_hash", url:"http://exhentai.org/"}, function(){});
-		chrome.cookies.remove({name:"ipb_session_id", url:"http://exhentai.org/"}, function(){});
+		chrome.cookies.remove({name:"yay", url:"https://exhentai.org/"}, function(){});
+		chrome.cookies.remove({name:"ipb_anonlogin", url:"https://exhentai.org/"}, function(){});
+		chrome.cookies.remove({name:"ipb_member_id", url:"https://exhentai.org/"}, function(){});
+		chrome.cookies.remove({name:"ipb_pass_hash", url:"https://exhentai.org/"}, function(){});
+		chrome.cookies.remove({name:"ipb_session_id", url:"https://exhentai.org/"}, function(){});
 		chrome.cookies.remove({name:"ipb_anonlogin", url:"http://e-hentai.org/"}, function(){});
 		chrome.cookies.remove({name:"ipb_member_id", url:"http://e-hentai.org/"}, function(){});
 		chrome.cookies.remove({name:"ipb_pass_hash", url:"http://e-hentai.org/"}, function(){});

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -8,13 +8,13 @@
 	"content_scripts": [
 		{
 			"run_at": "document_start",
-			"matches": ["http://exhentai.org/", "http://exhentai.org/#"],
+			"matches": ["https://exhentai.org/", "https://exhentai.org/#"],
 			"css": ["css/bootstrap.min.css", "css/bootstrap-theme.min.css", "css/login.css"],
 			"js": ["lib/jquery.min.js", "lib/bootstrap.min.js", "lib/ex.js"]
 		},
 		{
 			"run_at": "document_start",
-			"matches": ["http://exhentai.org/*"],
+			"matches": ["https://exhentai.org/*"],
 			"js": ["lib/jquery.min.js", "lib/logout.js"]
 		}
 	],

--- a/firefox/data/js/exhentai.js
+++ b/firefox/data/js/exhentai.js
@@ -70,7 +70,7 @@ function loginToEhResult(r) {
         
         //alert('Login successful, we\'re sending you back to the home page now!');
         
-        window.location.href = 'http://exhentai.org';
+        window.location.href = 'https://exhentai.org';
     }
 }
 
@@ -127,7 +127,7 @@ $(function() {
     //safe html and annoying jquery templating
     b.append(
         $("<div>", { align: "center" })
-            .append($("<img>", { src: "http://exhentai.org", alt: "Sad Panda is Sad" }))
+            .append($("<img>", { src: "https://exhentai.org", alt: "Sad Panda is Sad" }))
 	    .append($("<div>", { id: "errorMsg", class: "alert alert-danger", style: "visibility:hidden; text-align: left;" }))
     );
 

--- a/firefox/data/js/redirect.js
+++ b/firefox/data/js/redirect.js
@@ -3,7 +3,7 @@
 	var menu = $('#nb');
 
 	if(exSrc.length) {
-		window.location.href = 'http://exhentai.org/login';
+		window.location.href = 'https://exhentai.org/login';
 	} else if(menu.length) {
 
 		menu.append($("<img>", { src: "http://st.exhentai.net/img/mr.gif", alt: "" }));
@@ -15,7 +15,7 @@
     			deleteLocalCookie('ipb_session_id');
     			deleteLocalCookie('ipb_member_id');
     			deleteLocalCookie('ipb_pass_hash');	
-			window.location.href = 'http://exhentai.org/login';	
+			window.location.href = 'https://exhentai.org/login';	
 			return false;	
 		});
 	}

--- a/firefox/lib/main.js
+++ b/firefox/lib/main.js
@@ -12,13 +12,13 @@
 exports.main = function() {
 
 	pageMod.PageMod({
-		include: "http://exhentai.org*",
+		include: "https://exhentai.org*",
 		contentScriptWhen: "end",
 		contentScriptFile: [self.data.url("js/jquery.js"), self.data.url("js/redirect.js")]
 	});
 
     	pageMod.PageMod({
-		include: "http://exhentai.org/login",		
+		include: "https://exhentai.org/login",		
 		contentScriptWhen: "end",
 		contentScriptFile: [self.data.url("js/jquery.js"), self.data.url("js/exhentai.js")],
 


### PR DESCRIPTION
exhentai switched to https and the current version of the extension isn't working anymore. I opened every file with a text editor and did a plain replace of "http://ex" with "https://ex", according to [this quick fix](http://haruhichan.com/forum/showthread.php?25188-Chrome-ExHentai-Easy-v2-Get-past-sad-panda!/page18&p=92802#post92802).
No testing has been done!